### PR TITLE
URL Cleanup

### DIFF
--- a/sentiments/README.adoc
+++ b/sentiments/README.adoc
@@ -8,7 +8,7 @@
 
 === about
 
-This function performs sentiment analysis using the http://textblob.readthedocs.io/en/dev/[textblob] natural language processing package.
+This function performs sentiment analysis using the https://textblob.readthedocs.io/en/dev/[textblob] natural language processing package.
 It is intendended to work with a twitter feed, rendered as json. The analyzer only looks at the `text` field, so any valid json containing 
 `text` will work. The output includes the text along with a computed polarity indicating the sentiment. The value ranges from -1.0 to 1.0, where 
 0.0 is neutral, and values reflect the degree positive or negative sentiment accordingly. 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://textblob.readthedocs.io/en/dev/ with 1 occurrences migrated to:  
  https://textblob.readthedocs.io/en/dev/ ([https](https://textblob.readthedocs.io/en/dev/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 2 occurrences